### PR TITLE
Minor typo fix: canvas.md -> canva.md

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -171,7 +171,7 @@ An R package providing color palettes for pro sports teams.
 
 The `ggthemes` package include the 150 four-color palettes from the [canva.com](canva.com). Doe to the size and limited number of colors in the palettes these palettes will be featured on their own page and only once.
 
-- [Canva colors](canvas.md)
+- [Canva colors](canva.md)
 
 ## Palettes sorted by Package (alphabetically)
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Many of the palettes in sports related palettes have a very limited number of co
 
 The `ggthemes` package include the 150 four-color palettes from the [canva.com](canva.com). Doe to the size and limited number of colors in the palettes these palettes will be featured on their own page and only once.
 
--   [Canva colors](canvas.md)
+-   [Canva colors](canva.md)
 
 Palettes sorted by Package (alphabetically)
 -------------------------------------------


### PR DESCRIPTION
Very minor typo fix to the link to the Canva palettes doc.